### PR TITLE
Update parameters are generated for the access token payload

### DIFF
--- a/lib/omniauth-square/version.rb
+++ b/lib/omniauth-square/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Square
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/lib/omniauth/strategies/square.rb
+++ b/lib/omniauth/strategies/square.rb
@@ -71,7 +71,7 @@ module OmniAuth
           :redirect_uri => callback_url
         }
 
-        params.merge! client.auth_code.client_params
+        params.merge! client.redirection_params
         params.merge! token_params.to_hash(:symbolize_keys => true)
 
         opts = {

--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 1.3.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2.0'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
This fixes an issue when updating the oauth2 gem past version 1.3.0. After
version 1.3.0, the `client_params` is no longer available. This changes the
definition to work with later versions of the oauth2 gem.

Breaking `oauth2` change https://github.com/oauth-xx/oauth2/commit/14ab0e000a84f1012d3000ee2b39bb74fb172b36#diff-eaea198ea716a3be034d65012242c94b